### PR TITLE
CI: add pub_dashboard_job

### DIFF
--- a/.github/workflows/update-fluttercandies-profile-readme.yml
+++ b/.github/workflows/update-fluttercandies-profile-readme.yml
@@ -64,7 +64,7 @@ jobs:
         uses: AmosHuKe/pub-dashboard@v1
         with:
           github_token: ${{ secrets.PERSON_TOKEN }}
-          github_repo: "https://github.com/AmosHuKe/pub-dashboard"
+          github_repo: "https://github.com/fluttercandies/.github"
           filename: "profile/README.md"
           publisher_list: "fluttercandies.com"
           package_list: "flutter_tilt,scrollview_observer,dext,flutter_custom_calendar,draggable_container,flutter_filereader,flutter_image_compress,flutter_live_activities,harmony_os_version,nav_router,saver_gallery,upgrade_tool,w_popup_menu,w_reorder_list"

--- a/.github/workflows/update-fluttercandies-profile-readme.yml
+++ b/.github/workflows/update-fluttercandies-profile-readme.yml
@@ -56,3 +56,17 @@ jobs:
           git add .
           git commit -m "Update profile/README.md from CI"
           git push
+  pub_dashboard_job:
+    runs-on: ubuntu-latest
+    name: pub-dashboard FlutterCandies .github/profile/README.md
+    steps:
+      - name: run pub-dashboard
+        uses: AmosHuKe/pub-dashboard@v1
+        with:
+          github_token: ${{ secrets.PERSON_TOKEN }}
+          github_repo: "https://github.com/AmosHuKe/pub-dashboard"
+          filename: "profile/README.md"
+          publisher_list: "fluttercandies.com"
+          package_list: "flutter_tilt,scrollview_observer,dext,flutter_custom_calendar,draggable_container,flutter_filereader,flutter_image_compress,flutter_live_activities,harmony_os_version,nav_router,saver_gallery,upgrade_tool,w_popup_menu,w_reorder_list"
+          sort_field: "published"
+          sort_mode: "asc"

--- a/.github/workflows/update-fluttercandies-profile-readme.yml
+++ b/.github/workflows/update-fluttercandies-profile-readme.yml
@@ -61,7 +61,7 @@ jobs:
     name: pub-dashboard FlutterCandies .github/profile/README.md
     steps:
       - name: run pub-dashboard
-        uses: AmosHuKe/pub-dashboard@v1
+        uses: AmosHuKe/pub-dashboard@v1.0.0
         with:
           github_token: ${{ secrets.PERSON_TOKEN }}
           github_repo: "https://github.com/fluttercandies/.github"

--- a/.github/workflows/update-fluttercandies-profile-readme.yml
+++ b/.github/workflows/update-fluttercandies-profile-readme.yml
@@ -57,6 +57,7 @@ jobs:
           git commit -m "Update profile/README.md from CI"
           git push
   pub_dashboard_job:
+    needs: make_org_repo_list
     runs-on: ubuntu-latest
     name: pub-dashboard FlutterCandies .github/profile/README.md
     steps:


### PR DESCRIPTION
cc/ @CaiJingLong @zmtzawqlp 

关联 PR：https://github.com/fluttercandies/.github/pull/2

pub-dashboard 目前更新行为是：
先通过 `publisher_list: "fluttercandies.com"` 的配置，获取 fluttercandies.com 下的所有 package，
部分未发布在 fluttercandies.com 的 package，通过 `package_list: "aa,bb,cc"` 的配置获取，
两者合并去重 package 的信息。