### PR TITLE
chore(deps): bump AmosHuKe/pub-dashboard to v1.1.5

### DIFF
--- a/.github/workflows/update-fluttercandies-profile-readme.yml
+++ b/.github/workflows/update-fluttercandies-profile-readme.yml
@@ -66,7 +66,7 @@ jobs:
     name: pub-dashboard FlutterCandies .github/profile/README.md
     steps:
       - name: run pub-dashboard
-        uses: AmosHuKe/pub-dashboard@a105a4f1a2f4005af80a991c65867ab0ec78bbf9 #v1.1.4
+        uses: AmosHuKe/pub-dashboard@380aee169b4e3aed3aa4f5f54b3f41dd5b9c654c #v1.1.5
         with:
           github_token: ${{ secrets.PERSON_TOKEN }}
           github_repo: "https://github.com/fluttercandies/.github"


### PR DESCRIPTION
Fix the error caused by the `Publisher` search limit.
Each `Publisher` can search up to 10 pages (100 packages).